### PR TITLE
chore: fix broken TwitterDev link to new XDevelopers

### DIFF
--- a/x-for-websites/x-for-websites.mdx
+++ b/x-for-websites/x-for-websites.mdx
@@ -36,7 +36,7 @@ An [embedded Tweet](https://developer.x.com/en/docs/twitter-for-websites/embedd
 
 </Card>
 <Card>
-  [Tweets by TwitterDev](https://x.com/TwitterDev?ref_src=twsrc%5Etfw)
+  [Tweets by XDevelopers](https://x.com/XDevelopers?ref_src=twsrc%5Etfw)
 </Card>
 </CardGroup>
 


### PR DESCRIPTION
Long overdue now that TwitterDev points to an invalid account.