### PR TITLE
docs: fix broken Python XDK repository link

### DIFF
--- a/tools/python-xdk.mdx
+++ b/tools/python-xdk.mdx
@@ -5,9 +5,9 @@ description: Install and use the official Python XDK client library for the X AP
 keywords: ["Python SDK", "XDK", "Python", "X API", "client library", "pip", "xdk"]
 ---
 
-The [Python XDK](https://github.com/xdevplatform/xdk-py) is the official client library for the X API v2. It handles authentication, pagination, and streaming so you can focus on building.
+The [Python XDK](https://github.com/xdevplatform/xdk-python) is the official client library for the X API v2. It handles authentication, pagination, and streaming so you can focus on building.
 
-<Card title="GitHub repository" icon="github" href="https://github.com/xdevplatform/xdk-py">
+<Card title="GitHub repository" icon="github" href="https://github.com/xdevplatform/xdk-python">
   Source code, issues, and releases.
 </Card>
 


### PR DESCRIPTION
## Summary
The Python XDK page links to `https://github.com/xdevplatform/xdk-py`, which returns a 404. The correct repository is `https://github.com/xdevplatform/xdk-python`.

## Changes
Updated both occurrences on `tools/python-xdk.mdx` (the intro link and the "GitHub repository" card) to point to `https://github.com/xdevplatform/xdk-python`.