### PR TITLE
docs: replace local XMCP with hosted X MCP via xurl

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -23,7 +23,7 @@ This document provides guidance for AI agents, coding assistants, and LLM-based 
    - Every page supports this. Use it instead of the HTML view when possible.
 
 4. **MCP Server** (for tool-using agents)
-   - https://docs.x.com/tools/mcp — Full Model Context Protocol server exposing 200+ X API endpoints + documentation search.
+   - https://docs.x.com/tools/mcp — Hosted X MCP (`api.x.com/mcp` via `xurl`) + documentation search MCP.
 
 5. **skill.md** (capability summary)
    - https://docs.x.com/skill.md — Structured description of every action an agent can perform with the X API (agentskills.io format).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ This document provides guidance for AI agents, coding assistants, and LLM-based 
    - Every page supports this. Use it instead of the HTML view when possible.
 
 4. **MCP Server** (for tool-using agents)
-   - https://docs.x.com/tools/mcp — Full Model Context Protocol server exposing 200+ X API endpoints + documentation search.
+   - https://docs.x.com/tools/mcp — Hosted X MCP (`api.x.com/mcp` via `xurl`) + documentation search MCP.
 
 5. **skill.md** (capability summary)
    - https://docs.x.com/skill.md — Structured description of every action an agent can perform with the X API (agentskills.io format).

--- a/llms.txt
+++ b/llms.txt
@@ -32,7 +32,7 @@
 - [llms-full.txt](https://docs.x.com/llms-full.txt): Entire documentation set as a single Markdown file (maximum context)
 - [Raw Markdown for any page](https://docs.x.com/tools/llms-txt.md): Append `.md` to any docs.x.com URL
 - [skill.md](https://docs.x.com/tools/skill-md.md): Structured capability summary (agentskills.io)
-- [MCP Server](https://docs.x.com/tools/mcp.md): Model Context Protocol server for X API tools + docs search
+- [MCP Server](https://docs.x.com/tools/mcp.md): Hosted X MCP (api.x.com/mcp via xurl) + docs search MCP
 - [OpenAPI Specification](https://docs.x.com/openapi.json): Machine-readable contract
 
 All pages are also available under `/.well-known/llms.txt`. Every documentation page supports the `.md` suffix for clean Markdown retrieval by agents.

--- a/tools/ai.mdx
+++ b/tools/ai.mdx
@@ -19,7 +19,7 @@ Give your AI agent the ability to call X API endpoints directly.
 
 | Resource | What it does | URL |
 |:---------|:------------|:----|
-| **XMCP** | MCP server — agents can create posts, search, look up users, etc. | [github.com/xdevplatform/xmcp](https://github.com/xdevplatform/xmcp) |
+| **X MCP** | Hosted MCP server — agents can search, look up users, manage bookmarks, and more | [docs.x.com/tools/mcp](/tools/mcp) |
 | **OpenAPI Spec** | Machine-readable API definition for code generation and agent tooling | [api.x.com/2/openapi.json](https://api.x.com/2/openapi.json) |
 
 ---

--- a/tools/mcp.mdx
+++ b/tools/mcp.mdx
@@ -22,16 +22,14 @@ The X API exposes a hosted **Streamable HTTP** MCP server at **`https://api.x.co
 
 ### Capabilities at a glance
 
-| Category | What the model can do | Tools |
-|---|---|---|
-| **Posts** | Fetch posts, see likers / reposters / quoters, recent counts | 7 |
-| **Search** | Full-archive post search, user search, news search | 3 |
-| **Users** | Resolve the current user, look up by id / handle, read a user's posts, timeline, and mentions | 7 |
-| **Bookmarks** | List / add / remove bookmarks and manage bookmark folders | 6 |
-| **News & Trends** | Get news stories, get trends for a location (WOEID) | 2 |
-| **Articles** | Create draft Articles and publish them | 2 |
-
-**27 tools total.**
+| Category | What the model can do |
+|---|---|
+| **Posts** | Fetch posts, see likers / reposters / quoters, recent counts |
+| **Search** | Full-archive post search, user search, news search |
+| **Users** | Resolve the current user, look up by id / handle, read a user's posts, timeline, and mentions |
+| **Bookmarks** | List / add / remove bookmarks and manage bookmark folders |
+| **News & Trends** | Get news stories, get trends for a location (WOEID) |
+| **Articles** | Create draft Articles and publish them |
 
 ### How it works
 

--- a/tools/mcp.mdx
+++ b/tools/mcp.mdx
@@ -42,7 +42,7 @@ flowchart LR
     B <-- "OAuth2 PKCE login + auto-refresh" --> D["X OAuth"]
 ```
 
-- The bridge is **[xurl](https://github.com/xdevplatform/xurl)** — install it locally and run `xurl mcp` (recommended). You can also run it with `npx` if you prefer not to install a binary.
+- The bridge runs via the **npm launcher** (`npx`), so there is **no separate install step**.
 - On **first run with no cached token**, it opens your browser for a one-time OAuth2 login, then caches and **auto-refreshes** the token forever after.
 - All diagnostics go to **stderr**; **stdout stays a clean JSON-RPC channel**.
 
@@ -51,15 +51,13 @@ flowchart LR
 1. **Create an X app** in the [X Developer Portal](https://developer.x.com) with **OAuth 2.0** enabled.
 2. **Register the redirect URI** `http://localhost:8080/callback` on the app (required for the first-run browser login). To use a different one, set `REDIRECT_URI` and register that instead.
 3. **Copy your `CLIENT_ID` and `CLIENT_SECRET`** — you'll put them in the client config.
-4. **Install [xurl](https://github.com/xdevplatform/xurl)** (recommended):
+4. **Have Node.js installed** (for `npx`). Optional native installs:
 
    ```bash
    brew install --cask xdevplatform/tap/xurl      # Homebrew
    npm install -g @xdevplatform/xurl              # npm (global)
    curl -fsSL https://raw.githubusercontent.com/xdevplatform/xurl/main/install.sh | bash
    ```
-
-   If you skip the install, you can run the bridge with Node.js via `npx -y @xdevplatform/xurl mcp …` instead — client examples below use the installed `xurl` binary.
 
 <Note>
 **First login needs a browser.** On a headless/remote box, authenticate out-of-band first with `xurl auth oauth2 --headless` (paste-a-code flow), then the bridge just reuses the cached token. See [Headless](#headless--remote-machines).
@@ -69,21 +67,21 @@ flowchart LR
 
 #### 1. Grok Build
 
-Add the server with one command (the `-e` flags become the server's environment):
+Add the server with one command (the `-e` flags become the server's environment, args after `--` go to `npx`):
 
 ```bash
-grok mcp add xapi xurl \
+grok mcp add xapi npx \
   -e CLIENT_ID=YOUR_X_APP_CLIENT_ID \
   -e CLIENT_SECRET=YOUR_X_APP_CLIENT_SECRET \
-  -- mcp https://api.x.com/mcp
+  -- -y @xdevplatform/xurl mcp https://api.x.com/mcp
 ```
 
 That writes this to `~/.grok/config.toml` (you can also edit it directly):
 
 ```toml
 [mcp_servers.xapi]
-command = "xurl"
-args = ["mcp", "https://api.x.com/mcp"]
+command = "npx"
+args = ["-y", "@xdevplatform/xurl", "mcp", "https://api.x.com/mcp"]
 enabled = true
 startup_timeout_sec = 300          # give the first-run browser login time
 
@@ -109,8 +107,8 @@ Create `~/.cursor/mcp.json` (global, all projects) or `.cursor/mcp.json` (this p
 {
   "mcpServers": {
     "xapi": {
-      "command": "xurl",
-      "args": ["mcp", "https://api.x.com/mcp"],
+      "command": "npx",
+      "args": ["-y", "@xdevplatform/xurl", "mcp", "https://api.x.com/mcp"],
       "env": {
         "CLIENT_ID": "YOUR_X_APP_CLIENT_ID",
         "CLIENT_SECRET": "YOUR_X_APP_CLIENT_SECRET"
@@ -130,8 +128,8 @@ Edit `claude_desktop_config.json` (macOS: `~/Library/Application Support/Claude/
 {
   "mcpServers": {
     "xapi": {
-      "command": "xurl",
-      "args": ["mcp", "https://api.x.com/mcp"],
+      "command": "npx",
+      "args": ["-y", "@xdevplatform/xurl", "mcp", "https://api.x.com/mcp"],
       "env": { "CLIENT_ID": "YOUR_X_APP_CLIENT_ID", "CLIENT_SECRET": "YOUR_X_APP_CLIENT_SECRET" }
     }
   }
@@ -149,8 +147,8 @@ Add to `.vscode/mcp.json`:
   "servers": {
     "xapi": {
       "type": "stdio",
-      "command": "xurl",
-      "args": ["mcp", "https://api.x.com/mcp"],
+      "command": "npx",
+      "args": ["-y", "@xdevplatform/xurl", "mcp", "https://api.x.com/mcp"],
       "env": { "CLIENT_ID": "YOUR_X_APP_CLIENT_ID", "CLIENT_SECRET": "YOUR_X_APP_CLIENT_SECRET" }
     }
   }
@@ -159,16 +157,16 @@ Add to `.vscode/mcp.json`:
 
 #### 5. Any MCP client
 
-The recommended stdio config (installed `xurl`):
+The universal stdio config is:
 
 | Field | Value |
 |---|---|
-| `command` | `xurl` |
-| `args` | `["mcp", "https://api.x.com/mcp"]` |
+| `command` | `npx` |
+| `args` | `["-y", "@xdevplatform/xurl", "mcp", "https://api.x.com/mcp"]` |
 | `env` | `CLIENT_ID`, `CLIENT_SECRET` |
 | startup timeout | **≥ 300s** (so the first-run login can finish) |
 
-Without a local install, you can use the npm launcher instead: `"command": "npx"`, `"args": ["-y", "@xdevplatform/xurl", "mcp", "https://api.x.com/mcp"]` (requires Node.js).
+If you installed `xurl` natively, replace `command`/`args` with `"command": "xurl", "args": ["mcp", "https://api.x.com/mcp"]`.
 
 ### Authentication
 
@@ -239,17 +237,17 @@ Advanced env overrides (rarely needed): `AUTH_URL`, `TOKEN_URL`, `API_BASE_URL`,
 ```bash
 grok mcp doctor xapi          # Grok Build: end-to-end check
 # or test the bridge by hand (Ctrl-C to exit):
-xurl mcp https://api.x.com/mcp
+npx -y @xdevplatform/xurl mcp https://api.x.com/mcp
 ```
 
 | Symptom | Cause / Fix |
 |---|---|
 | Client times out on startup | Raise `startup_timeout_sec` to 300+; the bridge is waiting on your browser login |
-| Browser never opens | No display (headless) → run `xurl auth oauth2 --headless` first; ensure `xurl` is on your `PATH` |
+| Browser never opens | No display (headless) → run `xurl auth oauth2 --headless` first; ensure `npx` resolves |
 | `401` / `token refresh failed` | App credentials wrong, or refresh token revoked → re-run the login (`xurl auth oauth2 [--app NAME]`) |
 | Redirect/callback error in browser | `http://localhost:8080/callback` not registered on the app (or `REDIRECT_URI` mismatch) |
 | `client-not-enrolled` after login | App isn't in the right X package/environment → in the portal move it to **Pay-per-use** + **Production** |
-| `npx` pulls a stale version (if not using installed `xurl`) | Prefer installing [xurl](https://github.com/xdevplatform/xurl); or pin `--registry=https://registry.npmjs.org/` in `args` |
+| `npx` pulls a stale version | A private registry mirror is default → pin `--registry=https://registry.npmjs.org/` in `args` |
 | Empty/garbled tool output | Don't run the client with `--verbose`; stdout must stay a clean JSON-RPC channel |
 
 ### Security & best practices
@@ -298,8 +296,8 @@ You can connect both MCP servers simultaneously. This gives your AI assistant th
 
 ```toml
 [mcp_servers.xapi]
-command = "xurl"
-args = ["mcp", "https://api.x.com/mcp"]
+command = "npx"
+args = ["-y", "@xdevplatform/xurl", "mcp", "https://api.x.com/mcp"]
 enabled = true
 startup_timeout_sec = 300
 
@@ -318,8 +316,8 @@ enabled = true
 {
   "mcpServers": {
     "xapi": {
-      "command": "xurl",
-      "args": ["mcp", "https://api.x.com/mcp"],
+      "command": "npx",
+      "args": ["-y", "@xdevplatform/xurl", "mcp", "https://api.x.com/mcp"],
       "env": {
         "CLIENT_ID": "YOUR_X_APP_CLIENT_ID",
         "CLIENT_SECRET": "YOUR_X_APP_CLIENT_SECRET"

--- a/tools/mcp.mdx
+++ b/tools/mcp.mdx
@@ -51,7 +51,8 @@ flowchart LR
 1. **Create an X app** in the [X Developer Portal](https://developer.x.com) with **OAuth 2.0** enabled.
 2. **Register the redirect URI** `http://localhost:8080/callback` on the app (required for the first-run browser login). To use a different one, set `REDIRECT_URI` and register that instead.
 3. **Copy your `CLIENT_ID` and `CLIENT_SECRET`** — you'll put them in the client config.
-4. **Have Node.js installed** (for `npx`). Optional native installs:
+4. **Have Node.js installed** (for `npx`).
+5. We recommend you **install [xurl](https://github.com/xdevplatform/xurl)**:
 
    ```bash
    brew install --cask xdevplatform/tap/xurl      # Homebrew
@@ -60,7 +61,7 @@ flowchart LR
    ```
 
 <Note>
-**First login needs a browser.** On a headless/remote box, authenticate out-of-band first with `xurl auth oauth2 --headless` (paste-a-code flow), then the bridge just reuses the cached token. See [Headless](#headless--remote-machines).
+**First login needs a browser.** On a headless/remote box, authenticate out-of-band first with `xurl auth oauth2 --headless` (paste-a-code flow), then the bridge just reuses the cached token. See [Headless](/tools/mcp#headless-/-remote-machines).
 </Note>
 
 ### Connect your client

--- a/tools/mcp.mdx
+++ b/tools/mcp.mdx
@@ -1,106 +1,263 @@
 ---
 title: MCP Servers
 sidebarTitle: MCP
-description: Connect AI tools to the X API using Model Context Protocol servers for calling endpoints, searching the docs, and building agent workflows.
-keywords: ["XMCP", "MCP", "Model Context Protocol", "docs MCP", "AI agent", "AI tools", "Grok", "Cursor", "Windsurf", "OpenAPI", "MCP server"]
+description: Connect AI tools to the X API using Model Context Protocol — hosted X MCP via xurl, plus documentation search.
+keywords: ["XMCP", "MCP", "Model Context Protocol", "docs MCP", "AI agent", "AI tools", "Grok", "Cursor", "xurl", "OpenAPI", "MCP server"]
 ---
 
 Two [MCP](https://modelcontextprotocol.io) (Model Context Protocol) servers are available for working with X from AI tools:
 
 | Server | What it does | URL |
 |:-------|:-------------|:----|
-| **XMCP** | Call X API endpoints (create posts, search, look up users, etc.) | `http://127.0.0.1:8000/mcp` (local) |
+| **X MCP** | Call X API endpoints (search posts, look up users, bookmarks, trends, news, Articles, and more) | `https://api.x.com/mcp` (hosted; connect via `xurl mcp`) |
 | **Docs MCP** | Search and read X API documentation | `https://docs.x.com/mcp` (hosted) |
 
 ---
 
-## XMCP — X API endpoints
+## X MCP — X API
 
-[XMCP](https://github.com/xdevplatform/xmcp) is an official MCP server that exposes X API endpoints as callable tools. Run it locally and connect any MCP-compatible client — like Cursor, Windsurf, or your own agent — to read and write to X programmatically.
+Connect any MCP-compatible AI tool (Grok Build, Cursor, Claude, VS Code, …) directly to the **X API** so it can search the full archive, look up users, manage bookmarks, fetch trends and news, and draft Articles — all with your own X account's permissions.
 
-<CardGroup cols={2}>
-  <Card title="GitHub repository" icon="github" href="https://github.com/xdevplatform/xmcp">
-    Source code, setup instructions, and configuration.
-  </Card>
-  <Card title="What is MCP?" icon="circle-info" href="https://modelcontextprotocol.io">
-    Learn about the Model Context Protocol standard.
-  </Card>
-</CardGroup>
+The X API exposes a hosted **Streamable HTTP** MCP server at **`https://api.x.com/mcp`** (protocol `2025-06-18`, `serverInfo: xmcp`). You reach it through the open-source **`xurl mcp`** bridge, which handles OAuth for you and injects a fresh Bearer token on every call.
 
-XMCP loads the X API [OpenAPI specification](https://api.x.com/2/openapi.json) at startup and converts every operation into an MCP tool. Your AI assistant can then call these tools to interact with the X API — creating posts, searching, looking up users, and more.
+### Capabilities at a glance
 
-**Key features:**
+| Category | What the model can do | Tools |
+|---|---|---|
+| **Posts** | Fetch posts, see likers / reposters / quoters, recent counts | 7 |
+| **Search** | Full-archive post search, user search, news search | 3 |
+| **Users** | Resolve the current user, look up by id / handle, read a user's posts, timeline, and mentions | 7 |
+| **Bookmarks** | List / add / remove bookmarks and manage bookmark folders | 6 |
+| **News & Trends** | Get news stories, get trends for a location (WOEID) | 2 |
+| **Articles** | Create draft Articles and publish them | 2 |
 
-- **200+ tools** automatically generated from the OpenAPI spec — search posts, create posts, look up users, manage likes, and more
-- **OAuth 1.0a authentication** with browser-based consent flow
-- **Tool allow-listing** via `X_API_TOOL_ALLOWLIST` to restrict which API operations are available
-- **Works with any MCP client** — Cursor, Windsurf, or custom implementations
-- **Optional Grok test client** using the xAI API
+**27 tools total.**
 
-### Quick setup
+### How it works
 
-<Steps>
-  <Step title="Clone and install">
-    Requires Python 3.9+.
+X's OAuth requires *your own* developer app (there is no dynamic client registration, and `api.x.com/mcp` does not advertise native MCP OAuth discovery). So instead of pointing your client at the URL directly, you run a tiny local bridge that owns the app identity, performs the one-time login, and keeps the token fresh.
 
-    ```bash
-    git clone https://github.com/xdevplatform/xmcp && cd xmcp
-    python -m venv .venv && source .venv/bin/activate
-    pip install -r requirements.txt
-    ```
-  </Step>
-  <Step title="Configure credentials">
-    Copy the example environment file and add your X API credentials:
+```mermaid
+flowchart LR
+    A["MCP client<br/>(Grok Build, Cursor, …)"] -- "stdio JSON-RPC" --> B["xurl mcp<br/>(local bridge)"]
+    B -- "HTTPS + Authorization: Bearer" --> C[("api.x.com/mcp")]
+    B <-- "OAuth2 PKCE login + auto-refresh" --> D["X OAuth"]
+```
 
-    ```bash
-    cp env.example .env
-    ```
+- The bridge runs via the **npm launcher** (`npx`), so there is **no separate install step**.
+- On **first run with no cached token**, it opens your browser for a one-time OAuth2 login, then caches and **auto-refreshes** the token forever after.
+- All diagnostics go to **stderr**; **stdout stays a clean JSON-RPC channel**.
 
-    Edit `.env` with your app's OAuth consumer key, consumer secret, and bearer token from the [Developer Console](https://console.x.com). Set your callback URL (e.g., `http://127.0.0.1:8976/oauth/callback`) — make sure to register it in the Developer Console too.
-  </Step>
-  <Step title="Start the server">
-    ```bash
-    python server.py
-    ```
-    
-    The MCP server starts at `http://127.0.0.1:8000/mcp` by default. Host and port are configurable via environment variables.
-  </Step>
-  <Step title="Connect your AI tool">
-    Point your MCP-compatible client to `http://127.0.0.1:8000/mcp`. See the [XMCP README](https://github.com/xdevplatform/xmcp) for client-specific configuration.
-  </Step>
-</Steps>
+### Before you begin
 
-### Configuration
+1. **Create an X app** in the [X Developer Portal](https://developer.x.com) with **OAuth 2.0** enabled.
+2. **Register the redirect URI** `http://localhost:8080/callback` on the app (required for the first-run browser login). To use a different one, set `REDIRECT_URI` and register that instead.
+3. **Copy your `CLIENT_ID` and `CLIENT_SECRET`** — you'll put them in the client config.
+4. **Have Node.js installed** (for `npx`). Optional native installs:
 
-Add XMCP to your MCP client settings:
+   ```bash
+   brew install --cask xdevplatform/tap/xurl      # Homebrew
+   npm install -g @xdevplatform/xurl              # npm (global)
+   curl -fsSL https://raw.githubusercontent.com/xdevplatform/xurl/main/install.sh | bash
+   ```
+
+<Note>
+**First login needs a browser.** On a headless/remote box, authenticate out-of-band first with `xurl auth oauth2 --headless` (paste-a-code flow), then the bridge just reuses the cached token. See [Headless](#headless--remote-machines).
+</Note>
+
+### Connect your client
+
+#### 1. Grok Build
+
+Add the server with one command (the `-e` flags become the server's environment, args after `--` go to `npx`):
+
+```bash
+grok mcp add xapi npx \
+  -e CLIENT_ID=YOUR_X_APP_CLIENT_ID \
+  -e CLIENT_SECRET=YOUR_X_APP_CLIENT_SECRET \
+  -- -y @xdevplatform/xurl mcp https://api.x.com/mcp
+```
+
+That writes this to `~/.grok/config.toml` (you can also edit it directly):
+
+```toml
+[mcp_servers.xapi]
+command = "npx"
+args = ["-y", "@xdevplatform/xurl", "mcp", "https://api.x.com/mcp"]
+enabled = true
+startup_timeout_sec = 300          # give the first-run browser login time
+
+[mcp_servers.xapi.env]
+CLIENT_ID = "YOUR_X_APP_CLIENT_ID"
+CLIENT_SECRET = "YOUR_X_APP_CLIENT_SECRET"
+```
+
+Verify and list:
+
+```bash
+grok mcp doctor xapi      # ✓ server started, ✓ handshake OK, ✓ tools discovered
+grok mcp list
+```
+
+The first time a tool is invoked (or on `doctor`), your browser opens for the X login — complete it once and you're set.
+
+#### 2. Cursor
+
+Create `~/.cursor/mcp.json` (global, all projects) or `.cursor/mcp.json` (this project only):
 
 ```json
 {
   "mcpServers": {
-    "xmcp": {
-      "url": "http://127.0.0.1:8000/mcp"
+    "xapi": {
+      "command": "npx",
+      "args": ["-y", "@xdevplatform/xurl", "mcp", "https://api.x.com/mcp"],
+      "env": {
+        "CLIENT_ID": "YOUR_X_APP_CLIENT_ID",
+        "CLIENT_SECRET": "YOUR_X_APP_CLIENT_SECRET"
+      }
     }
   }
 }
 ```
 
-Once connected, you can ask your AI assistant to interact with X directly — "search for recent posts about AI", "look up @XDevelopers", or "create a post".
+Then open **Cursor → Settings → MCP**, confirm **xapi** shows a green dot and its tools. On first use Cursor spawns the bridge and your browser opens for login; the tool list populates once the handshake completes.
 
-### Tool allow-listing
+#### 3. Claude Desktop
 
-By default, XMCP exposes all X API operations as tools. Use the `X_API_TOOL_ALLOWLIST` environment variable to restrict which tools are available:
+Edit `claude_desktop_config.json` (macOS: `~/Library/Application Support/Claude/`, Windows: `%APPDATA%\Claude\`):
 
-```bash
-X_API_TOOL_ALLOWLIST="createPosts,getUsersByUsername,searchPostsRecent,likePost"
+```json
+{
+  "mcpServers": {
+    "xapi": {
+      "command": "npx",
+      "args": ["-y", "@xdevplatform/xurl", "mcp", "https://api.x.com/mcp"],
+      "env": { "CLIENT_ID": "YOUR_X_APP_CLIENT_ID", "CLIENT_SECRET": "YOUR_X_APP_CLIENT_SECRET" }
+    }
+  }
+}
 ```
 
-This is useful for limiting what an AI agent can do — for example, allowing read-only operations while blocking post creation or deletion.
+Restart Claude Desktop; the X tools appear in the tools (🔌) menu.
 
-### Limitations
+#### 4. VS Code (GitHub Copilot / Agent mode)
 
-- **No streaming or webhook endpoints** — these require persistent connections that don't fit the MCP request/response model
-- **Spec fetched at startup** — restart the server to pick up any API spec updates
-- **Tokens stored in memory** — OAuth tokens are not persisted across restarts
+Add to `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "xapi": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@xdevplatform/xurl", "mcp", "https://api.x.com/mcp"],
+      "env": { "CLIENT_ID": "YOUR_X_APP_CLIENT_ID", "CLIENT_SECRET": "YOUR_X_APP_CLIENT_SECRET" }
+    }
+  }
+}
+```
+
+#### 5. Any MCP client
+
+The universal stdio config is:
+
+| Field | Value |
+|---|---|
+| `command` | `npx` |
+| `args` | `["-y", "@xdevplatform/xurl", "mcp", "https://api.x.com/mcp"]` |
+| `env` | `CLIENT_ID`, `CLIENT_SECRET` |
+| startup timeout | **≥ 300s** (so the first-run login can finish) |
+
+If you installed `xurl` natively, replace `command`/`args` with `"command": "xurl", "args": ["mcp", "https://api.x.com/mcp"]`.
+
+### Authentication
+
+#### OAuth 2.0 user context (default)
+
+The bridge authenticates as **you** (PKCE flow), so tools act with your account's scopes. Resolution order for credentials: **`CLIENT_ID`/`CLIENT_SECRET` env vars → the active app in `~/.xurl`**. Tokens are cached in `~/.xurl` and refreshed automatically (including a forced refresh after a `401`).
+
+#### First-run browser login
+
+With no cached token, the bridge prints to stderr and opens your browser:
+
+```
+[xurl mcp] no valid OAuth2 token; opening the browser to sign in -- complete the login to start the bridge...
+[xurl mcp] authentication complete; starting bridge
+```
+
+The MCP handshake is held until you finish — that's why clients need a generous `startup_timeout_sec`.
+
+#### Headless / remote machines
+
+No reachable browser? Authenticate once out-of-band, then start the client:
+
+```bash
+xurl auth oauth2 --headless                 # prints an auth URL; you paste back the redirect URL/code
+xurl auth oauth2 --app my-app --headless    # for a specific app
+```
+
+#### App-only (direct URL, no bridge)
+
+For read endpoints you can skip the bridge and point a client straight at the URL with a **static App-only Bearer token** — useful for clients that support remote MCP with custom headers:
+
+```toml
+# ~/.grok/config.toml
+[mcp_servers.xapi_direct]
+url = "https://api.x.com/mcp"
+enabled = true
+
+[mcp_servers.xapi_direct.headers]
+Authorization = "Bearer YOUR_APP_ONLY_BEARER_TOKEN"
+```
+
+Trade-off: no auto-refresh and no user context (no actions as you). The bridge is recommended for full functionality.
+
+#### Multiple apps & accounts
+
+```bash
+xurl --app my-app mcp                  # bridge using a specific registered app
+xurl mcp -u alice https://api.x.com/mcp  # act as a specific OAuth2 user
+```
+
+In a client config, add `"--app", "my-app"` or `"-u", "alice"` to `args`.
+
+### Configuration reference
+
+| Setting | Where | Notes |
+|---|---|---|
+| `CLIENT_ID` / `CLIENT_SECRET` | `env` | Your X app credentials (or rely on a registered app in `~/.xurl`) |
+| `REDIRECT_URI` | `env` | Overrides the callback; must be registered on the app. Default `http://localhost:8080/callback` |
+| `startup_timeout_sec` | client config | Set **≥ 300** so first-run login can complete |
+| `[URL]` positional | `args` | Defaults to `https://api.x.com/mcp` |
+| `--app NAME` | `args` | Use a specific registered app |
+| `-u, --username` | `args` | Act as a specific OAuth2 user |
+
+Advanced env overrides (rarely needed): `AUTH_URL`, `TOKEN_URL`, `API_BASE_URL`, `INFO_URL`.
+
+### Verify & troubleshoot
+
+```bash
+grok mcp doctor xapi          # Grok Build: end-to-end check
+# or test the bridge by hand (Ctrl-C to exit):
+npx -y @xdevplatform/xurl mcp https://api.x.com/mcp
+```
+
+| Symptom | Cause / Fix |
+|---|---|
+| Client times out on startup | Raise `startup_timeout_sec` to 300+; the bridge is waiting on your browser login |
+| Browser never opens | No display (headless) → run `xurl auth oauth2 --headless` first; ensure `npx` resolves |
+| `401` / `token refresh failed` | App credentials wrong, or refresh token revoked → re-run the login (`xurl auth oauth2 [--app NAME]`) |
+| Redirect/callback error in browser | `http://localhost:8080/callback` not registered on the app (or `REDIRECT_URI` mismatch) |
+| `client-not-enrolled` after login | App isn't in the right X package/environment → in the portal move it to **Pay-per-use** + **Production** |
+| `npx` pulls a stale version | A private registry mirror is default → pin `--registry=https://registry.npmjs.org/` in `args` |
+| Empty/garbled tool output | Don't run the client with `--verbose`; stdout must stay a clean JSON-RPC channel |
+
+### Security & best practices
+
+- **Treat `~/.xurl` and access tokens as secrets** — don't paste them into chats, logs, or shared configs. Prefer per-project `.mcp.json`/`.grok/config.toml` that reference env vars over committing raw secrets.
+- **Use a dedicated app** for MCP with only the scopes you need.
+- **Writes count against rate limits** (bookmarks, `article_publish`) and are stricter than reads; expect occasional `429`s and back off.
+- **The bridge is local** — your credentials never leave your machine except as a Bearer token sent over TLS to `api.x.com`.
 
 ---
 
@@ -135,13 +292,38 @@ This is useful when you're building with the X API and want your AI assistant to
 
 ## Using both servers together
 
-You can connect both MCP servers simultaneously. This gives your AI assistant the ability to both look up documentation *and* call the API:
+You can connect both MCP servers simultaneously. This gives your AI assistant the ability to both look up documentation *and* call the API.
+
+**Grok Build** (`~/.grok/config.toml`):
+
+```toml
+[mcp_servers.xapi]
+command = "npx"
+args = ["-y", "@xdevplatform/xurl", "mcp", "https://api.x.com/mcp"]
+enabled = true
+startup_timeout_sec = 300
+
+[mcp_servers.xapi.env]
+CLIENT_ID = "YOUR_X_APP_CLIENT_ID"
+CLIENT_SECRET = "YOUR_X_APP_CLIENT_SECRET"
+
+[mcp_servers.x-docs]
+url = "https://docs.x.com/mcp"
+enabled = true
+```
+
+**Cursor / Claude-style** (`mcp.json`):
 
 ```json
 {
   "mcpServers": {
-    "xmcp": {
-      "url": "http://127.0.0.1:8000/mcp"
+    "xapi": {
+      "command": "npx",
+      "args": ["-y", "@xdevplatform/xurl", "mcp", "https://api.x.com/mcp"],
+      "env": {
+        "CLIENT_ID": "YOUR_X_APP_CLIENT_ID",
+        "CLIENT_SECRET": "YOUR_X_APP_CLIENT_SECRET"
+      }
     },
     "x-docs": {
       "url": "https://docs.x.com/mcp"
@@ -154,7 +336,7 @@ You can connect both MCP servers simultaneously. This gives your AI assistant th
 
 ## OpenAPI specification
 
-The machine-readable API specification for all X API v2 endpoints. This is the same spec that XMCP uses to generate its tools.
+The machine-readable API specification for all X API v2 endpoints.
 
 | Resource | URL |
 |:---------|:----|

--- a/tools/mcp.mdx
+++ b/tools/mcp.mdx
@@ -42,7 +42,7 @@ flowchart LR
     B <-- "OAuth2 PKCE login + auto-refresh" --> D["X OAuth"]
 ```
 
-- The bridge runs via the **npm launcher** (`npx`), so there is **no separate install step**.
+- The bridge is **[xurl](https://github.com/xdevplatform/xurl)** — install it locally and run `xurl mcp` (recommended). You can also run it with `npx` if you prefer not to install a binary.
 - On **first run with no cached token**, it opens your browser for a one-time OAuth2 login, then caches and **auto-refreshes** the token forever after.
 - All diagnostics go to **stderr**; **stdout stays a clean JSON-RPC channel**.
 
@@ -51,13 +51,15 @@ flowchart LR
 1. **Create an X app** in the [X Developer Portal](https://developer.x.com) with **OAuth 2.0** enabled.
 2. **Register the redirect URI** `http://localhost:8080/callback` on the app (required for the first-run browser login). To use a different one, set `REDIRECT_URI` and register that instead.
 3. **Copy your `CLIENT_ID` and `CLIENT_SECRET`** — you'll put them in the client config.
-4. **Have Node.js installed** (for `npx`). Optional native installs:
+4. **Install [xurl](https://github.com/xdevplatform/xurl)** (recommended):
 
    ```bash
    brew install --cask xdevplatform/tap/xurl      # Homebrew
    npm install -g @xdevplatform/xurl              # npm (global)
    curl -fsSL https://raw.githubusercontent.com/xdevplatform/xurl/main/install.sh | bash
    ```
+
+   If you skip the install, you can run the bridge with Node.js via `npx -y @xdevplatform/xurl mcp …` instead — client examples below use the installed `xurl` binary.
 
 <Note>
 **First login needs a browser.** On a headless/remote box, authenticate out-of-band first with `xurl auth oauth2 --headless` (paste-a-code flow), then the bridge just reuses the cached token. See [Headless](#headless--remote-machines).
@@ -67,21 +69,21 @@ flowchart LR
 
 #### 1. Grok Build
 
-Add the server with one command (the `-e` flags become the server's environment, args after `--` go to `npx`):
+Add the server with one command (the `-e` flags become the server's environment):
 
 ```bash
-grok mcp add xapi npx \
+grok mcp add xapi xurl \
   -e CLIENT_ID=YOUR_X_APP_CLIENT_ID \
   -e CLIENT_SECRET=YOUR_X_APP_CLIENT_SECRET \
-  -- -y @xdevplatform/xurl mcp https://api.x.com/mcp
+  -- mcp https://api.x.com/mcp
 ```
 
 That writes this to `~/.grok/config.toml` (you can also edit it directly):
 
 ```toml
 [mcp_servers.xapi]
-command = "npx"
-args = ["-y", "@xdevplatform/xurl", "mcp", "https://api.x.com/mcp"]
+command = "xurl"
+args = ["mcp", "https://api.x.com/mcp"]
 enabled = true
 startup_timeout_sec = 300          # give the first-run browser login time
 
@@ -107,8 +109,8 @@ Create `~/.cursor/mcp.json` (global, all projects) or `.cursor/mcp.json` (this p
 {
   "mcpServers": {
     "xapi": {
-      "command": "npx",
-      "args": ["-y", "@xdevplatform/xurl", "mcp", "https://api.x.com/mcp"],
+      "command": "xurl",
+      "args": ["mcp", "https://api.x.com/mcp"],
       "env": {
         "CLIENT_ID": "YOUR_X_APP_CLIENT_ID",
         "CLIENT_SECRET": "YOUR_X_APP_CLIENT_SECRET"
@@ -128,8 +130,8 @@ Edit `claude_desktop_config.json` (macOS: `~/Library/Application Support/Claude/
 {
   "mcpServers": {
     "xapi": {
-      "command": "npx",
-      "args": ["-y", "@xdevplatform/xurl", "mcp", "https://api.x.com/mcp"],
+      "command": "xurl",
+      "args": ["mcp", "https://api.x.com/mcp"],
       "env": { "CLIENT_ID": "YOUR_X_APP_CLIENT_ID", "CLIENT_SECRET": "YOUR_X_APP_CLIENT_SECRET" }
     }
   }
@@ -147,8 +149,8 @@ Add to `.vscode/mcp.json`:
   "servers": {
     "xapi": {
       "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@xdevplatform/xurl", "mcp", "https://api.x.com/mcp"],
+      "command": "xurl",
+      "args": ["mcp", "https://api.x.com/mcp"],
       "env": { "CLIENT_ID": "YOUR_X_APP_CLIENT_ID", "CLIENT_SECRET": "YOUR_X_APP_CLIENT_SECRET" }
     }
   }
@@ -157,16 +159,16 @@ Add to `.vscode/mcp.json`:
 
 #### 5. Any MCP client
 
-The universal stdio config is:
+The recommended stdio config (installed `xurl`):
 
 | Field | Value |
 |---|---|
-| `command` | `npx` |
-| `args` | `["-y", "@xdevplatform/xurl", "mcp", "https://api.x.com/mcp"]` |
+| `command` | `xurl` |
+| `args` | `["mcp", "https://api.x.com/mcp"]` |
 | `env` | `CLIENT_ID`, `CLIENT_SECRET` |
 | startup timeout | **≥ 300s** (so the first-run login can finish) |
 
-If you installed `xurl` natively, replace `command`/`args` with `"command": "xurl", "args": ["mcp", "https://api.x.com/mcp"]`.
+Without a local install, you can use the npm launcher instead: `"command": "npx"`, `"args": ["-y", "@xdevplatform/xurl", "mcp", "https://api.x.com/mcp"]` (requires Node.js).
 
 ### Authentication
 
@@ -237,17 +239,17 @@ Advanced env overrides (rarely needed): `AUTH_URL`, `TOKEN_URL`, `API_BASE_URL`,
 ```bash
 grok mcp doctor xapi          # Grok Build: end-to-end check
 # or test the bridge by hand (Ctrl-C to exit):
-npx -y @xdevplatform/xurl mcp https://api.x.com/mcp
+xurl mcp https://api.x.com/mcp
 ```
 
 | Symptom | Cause / Fix |
 |---|---|
 | Client times out on startup | Raise `startup_timeout_sec` to 300+; the bridge is waiting on your browser login |
-| Browser never opens | No display (headless) → run `xurl auth oauth2 --headless` first; ensure `npx` resolves |
+| Browser never opens | No display (headless) → run `xurl auth oauth2 --headless` first; ensure `xurl` is on your `PATH` |
 | `401` / `token refresh failed` | App credentials wrong, or refresh token revoked → re-run the login (`xurl auth oauth2 [--app NAME]`) |
 | Redirect/callback error in browser | `http://localhost:8080/callback` not registered on the app (or `REDIRECT_URI` mismatch) |
 | `client-not-enrolled` after login | App isn't in the right X package/environment → in the portal move it to **Pay-per-use** + **Production** |
-| `npx` pulls a stale version | A private registry mirror is default → pin `--registry=https://registry.npmjs.org/` in `args` |
+| `npx` pulls a stale version (if not using installed `xurl`) | Prefer installing [xurl](https://github.com/xdevplatform/xurl); or pin `--registry=https://registry.npmjs.org/` in `args` |
 | Empty/garbled tool output | Don't run the client with `--verbose`; stdout must stay a clean JSON-RPC channel |
 
 ### Security & best practices
@@ -296,8 +298,8 @@ You can connect both MCP servers simultaneously. This gives your AI assistant th
 
 ```toml
 [mcp_servers.xapi]
-command = "npx"
-args = ["-y", "@xdevplatform/xurl", "mcp", "https://api.x.com/mcp"]
+command = "xurl"
+args = ["mcp", "https://api.x.com/mcp"]
 enabled = true
 startup_timeout_sec = 300
 
@@ -316,8 +318,8 @@ enabled = true
 {
   "mcpServers": {
     "xapi": {
-      "command": "npx",
-      "args": ["-y", "@xdevplatform/xurl", "mcp", "https://api.x.com/mcp"],
+      "command": "xurl",
+      "args": ["mcp", "https://api.x.com/mcp"],
       "env": {
         "CLIENT_ID": "YOUR_X_APP_CLIENT_ID",
         "CLIENT_SECRET": "YOUR_X_APP_CLIENT_SECRET"

--- a/what-to-build.mdx
+++ b/what-to-build.mdx
@@ -178,7 +178,7 @@ Connect AI tools to the X API and build intelligent workflows.
 </CardGroup>
 
 **Get started:**
-- [XMCP](/tools/mcp#xmcp--x-api-endpoints) — MCP server for the X API
+- [X MCP](/tools/mcp#x-mcp--x-api) — Hosted MCP server for the X API
 - [llms-full.txt](https://docs.x.com/llms-full.txt) — Feed complete docs to your AI tool
 - [OpenAPI Spec](https://api.x.com/2/openapi.json) — Machine-readable API definition
 


### PR DESCRIPTION
Document api.x.com/mcp and the xurl mcp bridge for Grok, Cursor, Claude, and VS Code. Remove the detailed tool reference and create posts messaging; keep Docs MCP and update related links.