### PR TITLE
Document auto-recharge trigger semantics: at-threshold balance arms a top-up

### DIFF
--- a/x-api/getting-started/pricing.mdx
+++ b/x-api/getting-started/pricing.mdx
@@ -179,6 +179,10 @@ Enable auto-recharge to automatically top up your credit balance and avoid servi
 | **Recharge amount** | The amount to add when auto-recharge triggers (e.g., &dollar;25) |
 | **Trigger threshold** | Auto-recharge activates when your balance falls below this amount (e.g., &dollar;5) |
 
+#### When the trigger fires
+
+Auto-recharge triggers the first time your balance drops below the trigger threshold after having been **at or above** it. A balance exactly equal to the threshold counts as armed: if you purchase &dollar;5 of credits with a &dollar;5 trigger threshold, your very first spend takes the balance below the threshold and a top-up is triggered.
+
 <Note>
 Auto-recharge requires a saved payment method set as your default. You can cancel anytime in the Developer Console or by contacting support.
 </Note>


### PR DESCRIPTION
## What

Documents when auto-recharge actually fires, in the **Auto-recharge** section of the X API pricing page.

## Behavior documented

Auto-recharge triggers the first time the balance drops below the trigger threshold after having been **at or above** it. A balance exactly equal to the threshold counts as armed: purchasing $5 of credits with a $5 trigger threshold means the very first spend takes the balance below the threshold and triggers a top-up.

English source only; localized copies (ja/pt/ko/es) follow via the translation pipeline.